### PR TITLE
detect Mongoid 

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -214,7 +214,7 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def should_remove_tokens_after_password_reset?
-    if Rails::VERSION::MAJOR <= 5
+    if Rails::VERSION::MAJOR <= 5 || defined?(Mongoid)
       encrypted_password_changed? &&
         DeviseTokenAuth.remove_tokens_after_password_reset
     else


### PR DESCRIPTION
I opened an issue @mongoids tracker to implement the new ActiveRecord method. In the meanwhile this PR should work for Mongoid users: 
https://jira.mongodb.org/browse/MONGOID-4783

This method does not exist in Mongoid
`saved_change_to_attribute?(:encrypted_password)`
the old way works well
`encrypted_password_changed?`